### PR TITLE
chore(weekFour): align READMEs, trim noise, add Spotify context

### DIFF
--- a/.postman/tests.js
+++ b/.postman/tests.js
@@ -1,19 +1,3 @@
-/*
-Postman setup for Music Search Portfolio routes.
-
-Required Postman environment variables:
-- baseUrl (example: http://127.0.0.1:3001)
-- apiPrefix (example: /api/v42)
-- jwt (empty initially; set after OAuth callback response)
-- spotifyCode (manual one-time auth code from Spotify callback URL)
-- googleCode (manual one-time auth code from Google callback URL)
-
-Optional variables set by scripts:
-- lastResponseStatus
-- lastNoResults
-- firstTrackSpotifyUrl
-*/
-
 const Scripts = {
   common: `
 pm.test("Response status is success", function () {
@@ -80,43 +64,5 @@ const body = pm.response.json();
 pm.environment.set("lastNoResults", String(body.noResults));
 `,
 };
-
-/*
-Collection request definitions (copy each into Postman):
-
-1) GET {{baseUrl}}/
-   Tests tab: Scripts.common
-
-2) GET {{baseUrl}}{{apiPrefix}}/status
-   Tests tab: Scripts.common + Scripts.status
-
-3) GET {{baseUrl}}{{apiPrefix}}/auth/spotify/login
-   This redirects to Spotify OAuth.
-
-4) GET {{baseUrl}}{{apiPrefix}}/auth/google/login
-   This redirects to Google OAuth.
-
-5) GET {{baseUrl}}{{apiPrefix}}/auth/spotify/callback?code={{spotifyCode}}
-   Tests tab: Scripts.common + Scripts.oauthCallback
-
-6) GET {{baseUrl}}{{apiPrefix}}/auth/google/callback?code={{googleCode}}
-   Tests tab: Scripts.common + Scripts.oauthCallback
-
-7) GET {{baseUrl}}{{apiPrefix}}/auth/me
-   Headers: Authorization: Bearer {{jwt}}
-   Tests tab: Scripts.common + Scripts.me
-
-8) GET {{baseUrl}}{{apiPrefix}}/spotify/player-token
-   Headers: Authorization: Bearer {{jwt}}
-   Tests tab: Scripts.common + Scripts.playerToken
-
-9) GET {{baseUrl}}{{apiPrefix}}/search?q=daft%20punk&type=track&limit=10
-   Headers: Authorization: Bearer {{jwt}}
-   Tests tab: Scripts.common + Scripts.searchResults
-
-10) GET {{baseUrl}}{{apiPrefix}}/search?q=zzzzzzzzzzzzzzzzzzzz&type=track&limit=5
-    Headers: Authorization: Bearer {{jwt}}
-    Tests tab: Scripts.common + Scripts.searchNoResults
-*/
 
 module.exports = Scripts;

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,70 +1,66 @@
-# Backend Spotify OAuth + Search API (Week 2)
+# Backend API — Spotify OAuth & catalog
+
+Node.js (Express) + MongoDB backend for the portfolio Spotify integration. All JSON APIs are mounted under **`/api/v42`**.
+
+## Stack
+
+- Express 5, Mongoose, JWT auth  
+- Spotify OAuth (authorization code + refresh tokens stored per user)  
+- Axios for Spotify Web API calls  
 
 ## Architecture
-- Decoupled backend service using Node.js + Express + MongoDB (Mongoose).
-- All versioned API routes are prefixed with `/api/v42`.
-- JWT-based authorization gates protected Spotify routes.
-- Modular backend layering for portfolio review:
-  - `src/routes` for route registration
-  - `src/controllers` for HTTP handlers
-  - `src/services` for business logic and provider orchestration
 
-## Step 1: Spotify OAuth + JWT Persistence
-- Spotify OAuth implemented under `/api/v42/auth/...`.
-- `User` model stores profile data for Spotify provider:
-  - root identity fields (`email`, `displayName`)
-  - provider-specific data (`spotify`)
-  - session state (`sessions[]`)
-- OAuth login includes request `state` protection and callback validation.
-- Option A persistence pattern:
-  - Spotify `refreshToken` is persisted in MongoDB
-  - frontend receives short-lived JWT
-  - backend refreshes Spotify access tokens using stored refresh token
-- Protected identity check:
-  - `GET /api/v42/auth/me`
+- **`src/routes`** — route registration  
+- **`src/controllers`** — HTTP handlers  
+- **`src/services`** — Spotify and catalog logic  
+- **`src/middleware`** — OAuth state, JWT, Spotify token refresh  
 
-## Step 2: Spotify REST API Integration
-- Added versioned search proxy endpoint:
-  - `GET /api/v42/search?q=...&type=track&limit=10`
-- Added Spotify library endpoints:
-  - `GET /api/v42/spotify/favorites?limit=10` (saved tracks)
-- Behavior:
-  - Requires valid JWT (forces login before search)
-  - Validates stored Spotify authorization before protected Spotify requests
-  - Refreshes Spotify access token on-demand using persisted Spotify refresh token
-  - Proxies Spotify Search API response
-  - Returns UI-friendly transformed items with:
-    - `title`, `artist`, `album`, `image`
-    - `spotifyUrl`
-    - `external_urls.spotify`
-- No-results contract:
-  - `success: true`
-  - `noResults: true`
-  - `message`
-  - `items: []`
+Protected Spotify routes require a valid JWT **and** a linked Spotify account (refresh token on the user).
 
-## Player Support
-- Spotify scopes include Web Playback and library permissions.
-- Player token endpoint:
-  - `GET /api/v42/spotify/player-token`
-- OAuth scope additions for playback/library:
-  - `user-library-read`
+## Endpoints
 
-## Step 4: REST Client API Documentation
-- Added `backend/requests.http` with requests for:
-  - health check
-  - OAuth login route
-  - auth/me
-  - auth/session-status
-  - auth/refresh (Spotify access token refresh)
-  - player token
-  - favorites (saved tracks)
-  - search (results + no-results)
-- Added `.postman/collection.json` as a ready-to-import collection.
-- Jest and related test files were removed so VS Code REST Client is the single API testing workflow.
+Paths below are relative to your server origin (for example `http://127.0.0.1:3001`). Full paths always include the **`/api/v42`** prefix.
 
-## Environment Variables
-Copy `.env.dist` to `.env` and provide:
+### Public
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v42/` | Plain-text server banner |
+| GET | `/api/v42/status` | Health JSON (`status`, `message`) |
+| GET | `/api/v42/landing-catalog` | Landing-page catalog (songs, artists, albums) |
+| GET | `/api/v42/auth/spotify/login` | Start Spotify OAuth (redirect) |
+| GET | `/api/v42/auth/spotify/callback` | OAuth callback (returns JWT payload for the frontend) |
+
+### Authenticated (JWT `Authorization: Bearer`)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v42/auth/me` | Current user profile |
+| GET | `/api/v42/auth/session-status` | Session / Spotify link status |
+| POST | `/api/v42/auth/refresh` | Refresh Spotify access token via stored refresh token |
+
+### Spotify integration (JWT + linked Spotify account)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v42/spotify/player-token` | Short-lived token for Web Playback SDK |
+| GET | `/api/v42/spotify/favorites?limit=` | Saved tracks |
+| GET | `/api/v42/spotify/details?type=&id=` | Track, artist, or album detail (`type`: `track` \| `artist` \| `album`) |
+| POST | `/api/v42/spotify/play` | Body: `{ uri, deviceId? }` |
+| POST | `/api/v42/spotify/pause` | Body: `{ deviceId? }` |
+| GET | `/api/v42/search?q=&type=&limit=` | Search (`type`: e.g. `track`, `artist`) |
+
+No-results search contract: `success: true`, `noResults: true`, `message`, `items: []`.
+
+## Local testing
+
+- **`backend/requests.http`** — VS Code REST Client requests (variables: `baseUrl`, `apiPrefix`, `jwt`).  
+- **`.postman/`** — optional Postman collection and script snippets.  
+- **Tests:** `npm test` runs Jest (`backend/tests/endpoints.test.js`) against the mounted Express app.
+
+## Environment
+
+Copy `.env.dist` to `.env` and set:
 
 ```bash
 PORT=3001
@@ -77,13 +73,12 @@ JWT_SECRET=
 JWT_EXPIRES_IN=7d
 ```
 
-## Assignment Evidence
-- Spotify account signup and Spotify developer dashboard setup were completed outside the repo.
-- The provided dashboard screenshot confirms the developer app exists and is configured in Spotify for Developers.
-
 ## Run
+
 ```bash
 npm install
 npm test
 npm start
 ```
+
+Spotify dashboard configuration (redirect URI, client ID/secret) is managed in Spotify for Developers outside this repo.

--- a/backend/requests.http
+++ b/backend/requests.http
@@ -2,44 +2,49 @@
 @apiPrefix = /api/v42
 @jwt = REPLACE_WITH_JWT
 
-### STEP 0: Server root check
+###
+
 GET {{baseUrl}}/
 
-### STEP 1: API health check
+###
+
 GET {{baseUrl}}{{apiPrefix}}/status
 
-### STEP 2A: Start Spotify OAuth (open URL in browser)
+###
+
 GET {{baseUrl}}{{apiPrefix}}/auth/spotify/login
 
-### STEP 3A: Complete Spotify login in the browser.
-### The callback now requires OAuth state validation, so do not call it directly from REST Client.
-### After the browser redirect completes, paste the JWT from the frontend URL into @jwt above.
+###
 
-### STEP 4: Authenticated profile check
 GET {{baseUrl}}{{apiPrefix}}/auth/me
 Authorization: Bearer {{jwt}}
 
-### STEP 5: Session status (returns true/false style auth state)
+###
+
 GET {{baseUrl}}{{apiPrefix}}/auth/session-status
 Authorization: Bearer {{jwt}}
 
-### STEP 6: Refresh Spotify access token through the backend
+###
+
 POST {{baseUrl}}{{apiPrefix}}/auth/refresh
 Authorization: Bearer {{jwt}}
 
-### STEP 7: Spotify Web Playback token
-### Requires user to have Spotify connected (login via Step 3A at least once).
+###
+
 GET {{baseUrl}}{{apiPrefix}}/spotify/player-token
 Authorization: Bearer {{jwt}}
 
-### STEP 8: Fetch Spotify favorites (saved tracks)
+###
+
 GET {{baseUrl}}{{apiPrefix}}/spotify/favorites?limit=10
 Authorization: Bearer {{jwt}}
 
-### STEP 9: Search Spotify (expected results)
+###
+
 GET {{baseUrl}}{{apiPrefix}}/search?q=daft%20punk&type=track&limit=10
 Authorization: Bearer {{jwt}}
 
-### STEP 10: Search Spotify (expected no results contract)
+###
+
 GET {{baseUrl}}{{apiPrefix}}/search?q=zzzzzzzzzzzzzzzzzzzz&type=track&limit=5
 Authorization: Bearer {{jwt}}

--- a/backend/src/controllers/spotifyController.js
+++ b/backend/src/controllers/spotifyController.js
@@ -33,7 +33,6 @@ module.exports = {
         return response.status(400).json({ error: 'Query parameters "type" and "id" are required' });
       }
 
-      console.log('[DETAILS ENDPOINT]', { type, id });
       const payload = await getSpotifyDetail(request.spotifyAuth.accessToken, type, id);
       return response.json({ success: true, ...payload });
     } catch (error) {

--- a/backend/src/oauthProviders.js
+++ b/backend/src/oauthProviders.js
@@ -118,8 +118,6 @@ async function fetchSpotifyArtistDetail(accessToken, id) {
   const artistResponse = await axios.get(`${SPOTIFY_ARTISTS_URL}/${id}`, {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
-  console.log('[SPOTIFY RAW ARTIST]', artistResponse.data); 
-
   let topTracks = [];
   try {
     const topTracksResponse = await axios.get(`${SPOTIFY_ARTISTS_URL}/${id}/top-tracks`, {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,229 +1,77 @@
-# Frontend - Spotify at Midnight
+# Frontend — Spotify at Midnight
 
-React + Vite frontend for the Spotify integration project. The app handles Spotify OAuth, protects signed-in routes, and renders search and catalog content.
-## What It Does
+React (Vite) client for the portfolio Spotify app: OAuth handoff via JWT, protected routes, search, landing catalog, detail flows, preview playback, and Spotify Web Playback SDK when available.
 
-- Spotify sign-in flow with JWT handoff from the backend
-- Automatic redirect to the login screen when no JWT is available
-- Search for tracks and artists from the Spotify catalog
-- Browse saved tracks, artist picks, and landing-page catalog content
-- Playback controls with preview audio, Spotify Web Playback SDK support, shuffle, repeat, and a collapsible up-next queue
+## Scripts
 
-## Editor Setup
-
-This workspace includes VS Code recommendations for ligature-friendly editing.
-
-### Suggested Font
-
-- Fira Code
-- JetBrains Mono
-
-### Suggested Themes
-
-- Dracula Theme Official
-- One Dark Pro
-
-Ligatures are what make operators like `===`, `=>`, `!==`, and `>=` render in the fancy combined style. Make sure your font supports ligatures and that `editor.fontLigatures` is enabled.
-
-## Run
-
-```bash
-npm install
-npm run dev
-```
-
-## Build
-
-```bash
-npm run build
-```
+| Command | Description |
+|---------|-------------|
+| `npm install` | Install dependencies |
+| `npm run dev` | Vite dev server (default `http://127.0.0.1:5173`) |
+| `npm run build` | Production bundle to `dist/` |
+| `npm run preview` | Serve the production build locally |
+| `npm run lint` | ESLint |
 
 ## Environment
 
-Set the backend URL if it is not on localhost:
+Point the app at the backend if it is not on localhost:
 
 ```bash
 VITE_BACKEND_URL=http://127.0.0.1:3001
 ```
-# Frontend - Spotify at Midnight
 
-A Spotify-inspired web player UI built with React and Vite. Features OAuth authentication, real-time search, playback controls, and a beautiful Spotify-style interface.
-
-## Features
-
-### 🔐 Authentication
-- **Spotify OAuth Login** - Seamless login flow with Spotify account authorization
-- **Dedicated Login Page** - Full-screen login interface with feature highlights
-- **Protected Routes** - Automatic redirection to login when JWT is missing
-- **Session Management** - JWT stored in localStorage with automatic cleanup on logout
-
-### 🎵 Search & Discovery
-- **Real-time Search** - Search songs, artists, and albums across Spotify catalog
-- **Search History** - Recent searches saved locally for quick access
-- **Suggestions** - Personalized suggestions based on saved tracks
-- **Advanced Details Modal** - Full track/artist/album information with links to Spotify
-
-### 🎧 Playback Controls
-- **Multiple Playback Modes**:
-  - Preview audio (30-second clips)
-  - Spotify Web Playback SDK (full songs on Premium accounts)
-- **Transport Controls**:
-  - Previous/Next track navigation
-  - Play/Pause with visual feedback
-- **Advanced Playback**:
-  - **Shuffle** - Randomize queue with toggle
-  - **Repeat Modes** - Off, All (loop queue), One (repeat single track)
-- **Queue Management** - Collapsible "Up Next" section showing remaining tracks
-- **Current Track Display** - Always shows what's now playing in the sidebar
-
-### 📚 Library Features
-- **Saved Tracks** - Browse your Spotify saved/liked tracks
-- **Artist Picks** - Curated artists extracted from your saved tracks
-- **Landing Catalog** - Popular songs, artists, and albums on app load
-
-### 🎨 UI/UX
-- **Spotify-Inspired Design** - Dark theme matching Spotify's aesthetic
-- **Sidebar Navigation** - Quick access to Home, Search, Artists, Picks, Saved Tracks
-- **Media Carousels** - Swipeable card-based display for tracks and artists
-- **Responsive Layout** - Works on desktop and tablet (mobile optimizations in progress)
-- **Connection Status Panel** - Real-time device, session, and API connection info
-
-### 🎮 Player Interface
-- **Two-Row Button Layout**:
-  - Row 1: Previous | Play/Pause | Next (equal width)
-  - Row 2: Shuffle | Repeat (50% width each, pill-shaped)
-- **Large Visible Icons** - 1.6rem icons for easy interaction
-- **Color-Coded Buttons** - Primary green for play, secondary for controls
-- **Visual Feedback** - Active states for shuffle and repeat modes
-
-## Project Structure
+## Project layout
 
 ```
 frontend/
 ├── src/
-│   ├── App.jsx              # Main app component with routing & playback logic
-│   ├── App.css              # Global styles and layout
-│   ├── Login.jsx            # Dedicated login page component
-│   ├── Login.css            # Login page styling
-│   ├── ProtectedRoute.jsx   # Route protection wrapper
-│   ├── main.jsx             # App entry point
-│   └── index.css            # Base styles
+│   ├── App.jsx / App.css       # Shell, routing, playback & UI
+│   ├── Login.jsx / Login.css   # OAuth entry screen
+│   ├── ProtectedRoute.jsx      # JWT gate
+│   ├── contexts/
+│   │   └── SpotifyContext.jsx  # Shared API helper & cache (optional wiring)
+│   ├── main.jsx
+│   └── index.css
 ├── package.json
 └── README.md
 ```
 
-## API Integration
+## Features
 
-Backend API calls use `/api/v42` routes:
+- **Auth:** Spotify OAuth through the backend; JWT stored in `localStorage`; redirect to `/login` when missing.  
+- **Browse:** Search, saved tracks, artist picks, landing catalog, detail views with Spotify links.  
+- **Playback:** 30s previews where available; Web Playback SDK for full playback on supported accounts; shuffle, repeat (off / queue / one), collapsible queue.  
+- **UI:** Dark, Spotify-inspired layout; sidebar; carousels (Swiper); connection/debug panel.
 
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /auth/spotify/login` | Initiate Spotify OAuth |
-| `GET /auth/spotify/callback` | Handle OAuth redirect |
-| `GET /auth/me` | Get current user info |
-| `POST /auth/refresh` | Refresh Spotify access token |
-| `GET /search` | Search tracks/artists |
-| `GET /spotify/details` | Get detailed info (track/artist/album) |
-| `GET /spotify/favorites` | Get saved tracks |
-| `POST /spotify/play` | Start playback via device |
-| `POST /spotify/pause` | Pause playback |
-| `GET /spotify/player-token` | Get Spotify SDK token |
-| `GET /landing-catalog` | Get popular content for landing page |
+## Backend API (reference)
 
-## Environment Setup
+All routes are under **`/api/v42`** on the backend host (`VITE_BACKEND_URL`). Examples:
 
-```bash
-# Set backend URL if not on default localhost
-VITE_BACKEND_URL=http://127.0.0.1:3001
-```
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v42/auth/spotify/login` | Start OAuth |
+| GET | `/api/v42/auth/spotify/callback` | OAuth return |
+| GET | `/api/v42/auth/me` | Profile (Bearer JWT) |
+| POST | `/api/v42/auth/refresh` | Refresh Spotify token |
+| GET | `/api/v42/search` | Search |
+| GET | `/api/v42/spotify/details` | Track / artist / album detail |
+| GET | `/api/v42/spotify/favorites` | Saved tracks |
+| POST | `/api/v42/spotify/play` | Start playback |
+| POST | `/api/v42/spotify/pause` | Pause |
+| GET | `/api/v42/spotify/player-token` | SDK token |
+| GET | `/api/v42/landing-catalog` | Landing catalog |
 
-## Installation & Running
+## Stack
 
-```bash
-# Install dependencies
-npm install
-
-# Start development server
-npm run dev
-
-# Build for production
-npm build
-
-# Run production build preview
-npm preview
-```
-
-## Future Roadmap - Playlists
-
-### Phase 1: Basic Playlist Support
-- [ ] **Fetch User Playlists** - List all playlists in user's library
-- [ ] **Playlist Details View** - Show playlist name, description, cover, track count
-- [ ] **Browse Playlist Tracks** - Display all tracks in a playlist
-- [ ] **Play from Playlist** - Queue and play tracks from selected playlist
-- [ ] **Playlist Search** - Search within playlist tracks
-
-### Phase 2: Playlist Management  
-- [ ] **Create Playlist** - Create new empty playlists
-- [ ] **Add to Playlist** - Add current track/search results to playlist
-- [ ] **Remove from Playlist** - Remove tracks from playlist
-- [ ] **Reorder Tracks** - Drag-and-drop track ordering in playlists
-- [ ] **Edit Playlist** - Update name, description, cover image
-
-### Phase 3: Advanced Playlist Features
-- [ ] **Follow/Unfollow Playlists** - Track public/collaborative playlists
-- [ ] **Share Playlists** - Generate shareable links
-- [ ] **Collaborative Playlists** - Allow multiple users to edit
-- [ ] **Playlist Analytics** - View duration, popularity, etc.
-- [ ] **Duplicate Playlist** - Clone existing playlists
-
-## Backend Requirements for Playlists
-
-To support playlists, the backend needs these endpoints:
-
-```javascript
-// GET /api/v42/playlists
-// List all user playlists
-
-// GET /api/v42/playlists/:id
-// Get playlist details and tracks
-
-// POST /api/v42/playlists
-// Create new playlist
-// Body: { name, description?, public? }
-
-// PUT /api/v42/playlists/:id
-// Update playlist metadata
-
-// DELETE /api/v42/playlists/:id
-// Delete playlist
-
-// POST /api/v42/playlists/:id/add-tracks
-// Add tracks to playlist
-// Body: { trackIds: string[] }
-
-// DELETE /api/v42/playlists/:id/remove-tracks
-// Remove tracks from playlist
-// Body: { trackIds: string[] }
-
-// PUT /api/v42/playlists/:id/reorder-tracks
-// Reorder tracks in playlist
-// Body: { trackId, newPosition }
-```
-
-## Technology Stack
-
-- **React 19** - UI framework
-- **Vite** - Fast build tool
-- **React Router DOM** - Client-side routing
-- **Swiper** - Touch-enabled carousel component
-- **Spotify Web Playback SDK** - Native playback support
-- **ESLint** - Code quality
+React 19, Vite 5, React Router 7, Swiper, ESLint.
 
 ## Notes
 
-- Playback requires Spotify Premium account for full functionality
-- Preview audio (30s clips) available for all users
-- Search limited to Spotify's available catalog in your market
-- JWT tokens must be obtained from backend OAuth flow
-- All API calls require valid Bearer token authentication
+- Full-track playback through the SDK typically requires **Spotify Premium** and an active device / Web Playback setup.  
+- Preview URLs work more broadly when returned by the API.  
+- Search and catalog availability depend on Spotify’s rules for your market.  
+- Every authenticated API call expects `Authorization: Bearer <jwt>` from your backend login flow.
 
+## Playlist roadmap (future)
+
+Possible next steps: user playlists, playlist tracks, create/update playlists, collaborative features. Planned REST shapes would live under `/api/v42/playlists` (list, detail, CRUD, track add/remove/reorder — not implemented in this branch unless added in code).

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -24,6 +24,10 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react-refresh/only-export-components': [
+        'error',
+        { allowExportNames: ['useSpotify'] },
+      ],
     },
   },
 ])

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -223,7 +223,6 @@
   overflow: auto;
 }
 
-/* Queue Toggle Button */
 .queue-toggle {
   display: flex;
   align-items: center;
@@ -253,7 +252,6 @@
   flex-shrink: 0;
 }
 
-/* Queue Wrapper */
 .side-queue-wrapper {
   border: 1px solid rgba(85, 242, 161, 0.2);
   border-radius: 12px;
@@ -346,9 +344,14 @@
 }
 
 .playing-badge {
-  font-size: 0.6rem;
+  display: inline-flex;
+  align-items: center;
   color: var(--accent);
   flex-shrink: 0;
+}
+
+.playing-badge svg {
+  display: block;
 }
 
 .queue-item-artist {
@@ -370,17 +373,19 @@
   background: rgba(85, 242, 161, 0.2);
   color: var(--accent);
   cursor: pointer;
-  font-size: 0.75rem;
   transition: all 0.15s ease;
   flex-shrink: 0;
+}
+
+.queue-item-play svg {
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 .queue-item-play:hover {
   background: rgba(85, 242, 161, 0.3);
 }
 
-
-/* Repeat Button Styling */
 .repeat-button {
   position: relative;
 }
@@ -901,7 +906,6 @@ h1 {
   line-height: 1.5;
 }
 
-
 .details-modal-backdrop {
   position: fixed;
   inset: 0;
@@ -1143,7 +1147,6 @@ h1 {
   fill: currentColor;
 }
 
-/* Tablet: 760px and below */
 @media (max-width: 760px) {
   .clone-layout {
     grid-template-columns: 1fr;
@@ -1328,7 +1331,6 @@ h1 {
 
 }
 
-/* Mobile: 480px and below */
 @media (max-width: 480px) {
   #root {
     padding: 1rem 0.65rem 1.25rem;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,6 +50,14 @@ function PlaybackIcon({ isPlaying }) {
   );
 }
 
+function QueuePlayGlyph({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true" width="12" height="12">
+      <path d="M8 6v12l10-6z" fill="currentColor" />
+    </svg>
+  );
+}
+
 function PreviousIcon() {
   return (
     <svg className="transport-icon transport-icon-previous" viewBox="0 0 24 24" aria-hidden="true">
@@ -72,10 +80,8 @@ function RepeatIcon({ mode }) {
   return (
     <svg className={`transport-icon repeat-icon repeat-${mode}`} viewBox="0 0 24 24" aria-hidden="true">
       <g fill="currentColor" fillRule="evenodd">
-        {/* Repeat arrows */}
         <path d="M7 7h10v2l4-3-4-3v2H5v6h2V7zm10 10H7v-2l-4 3 4 3v-2h12v-6h-2v4z" />
       </g>
-      {/* Indicator for repeat mode */}
       {mode === 'one' && (
         <circle cx="18" cy="18" r="5" fill="currentColor" opacity="0.8" />
       )}
@@ -86,11 +92,8 @@ function RepeatIcon({ mode }) {
 function ShuffleIcon() {
   return (
     <svg className="transport-icon shuffle-icon" viewBox="0 0 24 24" aria-hidden="true">
-      {/* Top-left to bottom-right arrow */}
       <path d="M3 8h14v2H5l3 3-1.41 1.41L2.59 9 6.59 5 8 6.41 5 9.41V8z" fill="currentColor" />
-      {/* Bottom-left to top-right arrow */}
       <path d="M21 16H7v-2h12l-3-3 1.41-1.41L21.41 15l-4 4-1.41-1.41L20 16.59V16z" fill="currentColor" />
-      {/* Right side accent point */}
       <circle cx="20" cy="5" r="1.5" fill="currentColor" opacity="0.6" />
       <circle cx="4" cy="19" r="1.5" fill="currentColor" opacity="0.6" />
     </svg>
@@ -278,7 +281,7 @@ function AppContent({ jwtToken, setJwtToken }) {
     albums: [],
   });
   const [manualPlaybackQueue, setManualPlaybackQueue] = useState([]);
-  const [repeatMode, setRepeatMode] = useState('off'); // 'off', 'one', 'all'
+  const [repeatMode, setRepeatMode] = useState('off');
   const [isShuffled, setIsShuffled] = useState(false);
   const [isQueueOpen, setIsQueueOpen] = useState(false);
   const previewAudioRef = useRef(null);
@@ -841,8 +844,7 @@ function AppContent({ jwtToken, setJwtToken }) {
 
   const playNext = useCallback(() => {
     if (playbackQueue.length === 0) return;
-    
-    // Handle repeat one
+
     if (repeatMode === 'one') {
       if (nowPlaying?.id) {
         togglePreviewPlayback(nowPlaying, { preserveQueue: true });
@@ -851,7 +853,6 @@ function AppContent({ jwtToken, setJwtToken }) {
     }
     
     if (currentQueueIndex < 0 || currentQueueIndex >= playbackQueue.length - 1) {
-      // If repeat all is on, loop back to beginning
       if (repeatMode === 'all') {
         playQueueItemAt(0);
       }
@@ -870,11 +871,9 @@ function AppContent({ jwtToken, setJwtToken }) {
   const toggleShuffle = useCallback(() => {
     setIsShuffled(!isShuffled);
     if (!isShuffled && playbackQueue.length > 0) {
-      // Shuffle the queue and set as manual queue
       const shuffled = shuffleArray(playbackQueue);
       setManualPlaybackQueue(shuffled);
     } else {
-      // Return to original queue
       setManualPlaybackQueue([]);
     }
   }, [isShuffled, playbackQueue]);
@@ -1166,7 +1165,11 @@ function AppContent({ jwtToken, setJwtToken }) {
                       <span className="queue-index">{index + 1}</span>
                       <div className="queue-item-info">
                         <div className="queue-item-title">
-                          {index === currentQueueIndex && <span className="playing-badge">▶</span>}
+                          {index === currentQueueIndex && (
+                            <span className="playing-badge" aria-hidden="true">
+                              <QueuePlayGlyph />
+                            </span>
+                          )}
                           {item.title || item.name}
                         </div>
                         <div className="queue-item-artist">{item.artist || item.album || 'Unknown'}</div>
@@ -1177,7 +1180,7 @@ function AppContent({ jwtToken, setJwtToken }) {
                         onClick={() => playQueueItemAt(index)}
                         title="Play this track"
                       >
-                        ▶
+                        <QueuePlayGlyph />
                       </button>
                     </div>
                   ))}
@@ -1651,7 +1654,6 @@ function App() {
     const token = tokenFromUrl || localToken || '';
     if (tokenFromUrl) {
       localStorage.setItem('auth_jwt', tokenFromUrl);
-      // Clean up the URL to remove the token query parameter
       const params = new URLSearchParams(window.location.search);
       params.delete('token');
       const query = params.toString();
@@ -1660,7 +1662,6 @@ function App() {
     return token;
   });
 
-  // Redirect from /login to home if already authenticated
   if (jwtToken && window.location.pathname === '/login') {
     return <Navigate to="/" replace />;
   }

--- a/frontend/src/Login.css
+++ b/frontend/src/Login.css
@@ -1,4 +1,4 @@
-/* Login Container */
+
 .login-container {
   display: flex;
   flex-direction: column;
@@ -13,7 +13,6 @@
   overflow: hidden;
 }
 
-/* Decorative background elements */
 .login-container::before {
   content: '';
   position: absolute;
@@ -40,7 +39,6 @@
   z-index: 0;
 }
 
-/* Login Content */
 .login-content {
   position: relative;
   z-index: 1;
@@ -54,7 +52,6 @@
   backdrop-filter: blur(10px);
 }
 
-/* Login Header */
 .login-header {
   text-align: center;
   margin-bottom: 2.5rem;
@@ -104,7 +101,6 @@
   letter-spacing: 0.02em;
 }
 
-/* Login Body */
 .login-body {
   margin-bottom: 2.5rem;
 }
@@ -117,7 +113,6 @@
   text-align: center;
 }
 
-/* Spotify Auth Button */
 .btn-spotify-auth {
   width: 100%;
   display: flex;
@@ -162,7 +157,6 @@
   line-height: 1.5;
 }
 
-/* Login Features */
 .login-features {
   padding-top: 2rem;
   border-top: 1px solid rgba(29, 185, 84, 0.1);
@@ -193,12 +187,15 @@
 }
 
 .feature-icon {
-  font-size: 1.3rem;
-  min-width: 1.5rem;
-  text-align: center;
+  display: inline-block;
+  min-width: 0.5rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #1db954;
+  flex-shrink: 0;
 }
 
-/* Login Footer */
 .login-footer {
   position: relative;
   z-index: 1;
@@ -212,7 +209,6 @@
   margin: 0;
 }
 
-/* Responsive Design */
 @media (max-width: 600px) {
   .login-content {
     padding: 2rem 1.5rem;

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -19,7 +19,6 @@ function Login({ onSpotifyLogin }) {
     if (onSpotifyLogin) {
       onSpotifyLogin();
     } else {
-      // Redirect to backend OAuth endpoint
       window.location.href = `${BACKEND_URL}${API_PREFIX}/auth/spotify/login`;
     }
   };
@@ -66,19 +65,19 @@ function Login({ onSpotifyLogin }) {
           <h2 className="login-features-title">Features</h2>
           <ul className="login-features-list">
             <li>
-              <span className="feature-icon">🔍</span>
+              <span className="feature-icon" aria-hidden="true" />
               <span>Search songs, artists, and albums</span>
             </li>
             <li>
-              <span className="feature-icon">♥️</span>
+              <span className="feature-icon" aria-hidden="true" />
               <span>Browse your saved tracks</span>
             </li>
             <li>
-              <span className="feature-icon">🎵</span>
+              <span className="feature-icon" aria-hidden="true" />
               <span>Play music directly from the app</span>
             </li>
             <li>
-              <span className="feature-icon">✨</span>
+              <span className="feature-icon" aria-hidden="true" />
               <span>Discover artists from your library</span>
             </li>
           </ul>

--- a/frontend/src/ProtectedRoute.jsx
+++ b/frontend/src/ProtectedRoute.jsx
@@ -1,9 +1,5 @@
 import { Navigate } from 'react-router-dom';
 
-/**
- * ProtectedRoute component - ensures only authenticated users can access routes
- * Redirects to /login if no JWT token is found
- */
 function ProtectedRoute({ jwtToken, children }) {
   if (!jwtToken) {
     return <Navigate to="/login" replace />;

--- a/frontend/src/contexts/SpotifyContext.jsx
+++ b/frontend/src/contexts/SpotifyContext.jsx
@@ -1,0 +1,114 @@
+import React, { createContext, useContext, useCallback, useRef, useState } from 'react';
+
+const SpotifyContext = createContext(null);
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:3001';
+const API = '/api/v42';
+
+const CACHE_TTL = 1000 * 60 * 5;
+const RATE_LIMIT_KEY = 'spotify_rate_limit_reset';
+
+function sleep(ms) {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+async function fetchWithRetry(url, options = {}, retries = 3) {
+  let lastResponse = null;
+  
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, options);
+    lastResponse = res;
+
+    if (res.status !== 429) return res;
+
+    if (attempt === retries) {
+      return res;
+    }
+
+    const retryAfter = Number(res.headers.get('retry-after')) || 1;
+    const backoff = retryAfter * 1000 * Math.pow(2, attempt);
+
+    localStorage.setItem(RATE_LIMIT_KEY, String(Date.now() + backoff));
+    await sleep(backoff);
+  }
+
+  return lastResponse || new Response('Request failed', { status: 500 });
+}
+
+export function SpotifyProvider({ jwtToken, children }) {
+  const cacheRef = useRef(new Map());
+
+  const [recentlyViewed, setRecentlyViewed] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('recently_viewed') || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  const isRateLimited = () => {
+    const reset = Number(localStorage.getItem(RATE_LIMIT_KEY) || 0);
+    return Date.now() < reset;
+  };
+
+  const addRecentlyViewed = useCallback((item) => {
+    setRecentlyViewed((prev) => {
+      const next = [item, ...prev.filter((i) => i.id !== item.id)].slice(0, 10);
+      localStorage.setItem('recently_viewed', JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const request = useCallback(
+    async (endpoint) => {
+      const cacheKey = endpoint;
+      const cached = cacheRef.current.get(cacheKey);
+
+      if (cached && Date.now() - cached.time < CACHE_TTL) {
+        return cached.data;
+      }
+
+      if (isRateLimited()) {
+        throw new Error('Client is rate limited. Try again shortly.');
+      }
+
+      const res = await fetchWithRetry(`${BACKEND_URL}${API}${endpoint}`, {
+        headers: { Authorization: `Bearer ${jwtToken}` },
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        const errorMessage = errorData?.error || res.statusText || 'Request failed';
+        
+        if (res.status === 429) {
+          const retryAfter = Number(res.headers.get('retry-after')) || 1;
+          localStorage.setItem(RATE_LIMIT_KEY, String(Date.now() + retryAfter * 1000));
+        }
+        
+        throw new Error(errorMessage);
+      }
+
+      const data = await res.json();
+
+      cacheRef.current.set(cacheKey, {
+        data,
+        time: Date.now(),
+      });
+
+      return data;
+    },
+    [jwtToken]
+  );
+
+  const value = {
+    request,
+    recentlyViewed,
+    addRecentlyViewed,
+  };
+
+  return <SpotifyContext.Provider value={value}>{children}</SpotifyContext.Provider>;
+}
+
+export function useSpotify() {
+  return useContext(SpotifyContext);
+}


### PR DESCRIPTION
- Rewrite backend/frontend READMEs with accurate /api/v42 route tables
- Simplify requests.http and Postman tests; remove debug console.logs
- Add SpotifyContext scaffold; allow useSpotify for react-refresh
- UI: replace login emoji bullets, SVG play glyph in queue, strip comments